### PR TITLE
Added unsized integer grammar and snippet fix

### DIFF
--- a/grammars/verilog.cson
+++ b/grammars/verilog.cson
@@ -58,6 +58,10 @@
         'name': 'constant.numeric.sized_integer.verilog'
       }
       {
+        'match': '\\s\'[bBoOdDhH][a-fA-F0-9_xXzZ]+\\b'
+        'name': 'constant.numeric.unsized_integer.verilog'
+      }
+      {
         'captures':
           '1':
             'name': 'constant.numeric.integer.verilog'

--- a/snippets/language-verilog.cson
+++ b/snippets/language-verilog.cson
@@ -151,9 +151,9 @@
   'ifdef_simulation':
     'prefix': 'ifdef_sim'
     'body': """
-      'ifdef SIMULATION
+      `ifdef SIMULATION
       \t$0
-      'endif
+      `endif
     """
 
 
@@ -224,7 +224,7 @@
   'timescale':
     'prefix': 'timescale'
     'body': """
-      'timescale ${1:time} / ${2:time}
+      `timescale ${1:time} / ${2:time}
       $0
     """
 


### PR DESCRIPTION
Added unsized integer grammar (such as 'h4BE1). Previously fixed the 'timescale' and 'ifdef_simulation' snippets to use backticks instead of single qoute. Closing previous pull request which just included the snippets.